### PR TITLE
Discover and replace task refs anywhere in the description.

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -60,9 +60,9 @@ if (isset($_FILES['timelogs']))
 		// Take the task number out of the description
 		$description = $line[2];
 
-		preg_match('/^([A-Za-z]+\-\d+)/', $description, $matches);
+		preg_match('/\b([A-Za-z]+\-\d+)\b/', $description, $matches);
 		if (!empty($matches[1])) {
-		  $description = trim(str_replace($matches[1].' ', '', $description));
+		  $description = trim(preg_replace('/\b'.$matches[1].'\b/', '', $description));
 		}
 		$task = $matches[1];
 


### PR DESCRIPTION
Previously, a task ref had to be at the very beginning of the description to be detected, and have a space after to be replaced out. Now looks for the ref to be surrounded by any "word break" (space, beginning or end of string, etc).
