### PR TITLE
Replace hard-coded success link with appropriate config-reading logic

### DIFF
--- a/classes/tui_jira.php
+++ b/classes/tui_jira.php
@@ -17,15 +17,7 @@ class Tui_Jira
 
 		$start_time = microtime(true);
 
-		list($project_key, $issue_id) = explode('-', $issue_key);
-
-		if (isset($GLOBALS['config']['jira_instance'][strtoupper($project_key)])) {
-			$api_url = $GLOBALS['config']['jira_instance'][strtoupper($project_key)];
-		}
-		else {
-			$api_url = $GLOBALS['config']['jira_instance']['default'];
-		}
-
+		$api_url = self::get_instance_url($issue_key);
 		$url = $api_url.'/rest/api/2/issue/'.$issue_key.'/worklog?adjustEstimate=auto';
 
 		$request = array(
@@ -50,6 +42,18 @@ class Tui_Jira
 		self::$debug['call_timers'][$issue_key][] = microtime(true) - $start_time;
 
 		return $result['headers']['HTTP-Status'] == 201;
+	}
+
+	public static function get_instance_url($issue_key)
+	{
+		list($project_key, $issue_id) = explode('-', $issue_key);
+
+		if (isset($GLOBALS['config']['jira_instance'][strtoupper($project_key)])) {
+			return $GLOBALS['config']['jira_instance'][strtoupper($project_key)];
+		}
+		else {
+			return $GLOBALS['config']['jira_instance']['default'];
+		}
 	}
 
 	/**

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -10,15 +10,18 @@ if (isset($_GET['mode']) && $_GET['mode'] == 'save')
 		if ($task['log'])
 		{
 			$task_time = explode(':', $task['duration']);
-      $success = Tui_Jira::post_worklog($task['issue_key'], $task['description'], $_POST['date'].'T09:00:00.000-0000', "{$task_time[0]}h {$task_time[1]}m");
-      if ($success) {
-        echo '<a href="https://jira.tuisasweb.com/browse/'.htmlspecialchars(urlencode($task['issue_key'])).'">'.htmlspecialchars($task['issue_key'])."</a> logged successfully.<br>";
-      }
-      else {
-        echo '<strong style="color: red;">Error logging '.htmlspecialchars($task['issue_key']).'.</strong><br>';
-      }
+			$success = Tui_Jira::post_worklog($task['issue_key'], $task['description'], $_POST['date'].'T09:00:00.000-0000', "{$task_time[0]}h {$task_time[1]}m");
+			if ($success) {
+				echo '<a href="' . Tui_Jira::get_instance_url($task['issue_key']) . '/browse/'
+					. htmlspecialchars(urlencode($task['issue_key'])).'">'
+					. htmlspecialchars($task['issue_key'])."</a> logged successfully.<br>";
+			}
+			else {
+				echo '<strong style="color: red;">Error logging '.htmlspecialchars($task['issue_key']).'.</strong><br>';
+			}
 		}
 	}
+	echo '<hr />';
 	//Tui_Jira::print_timers();
 }
 


### PR DESCRIPTION
Retained the ability to uploaded to multiple JIRA instances at once, while linking to the correct one on success.
